### PR TITLE
Upgrade to grafana 9

### DIFF
--- a/controllers/config/operator_constants.go
+++ b/controllers/config/operator_constants.go
@@ -3,7 +3,7 @@ package config
 const (
 	// Grafana
 	GrafanaImage   = "docker.io/grafana/grafana"
-	GrafanaVersion = "7.5.11"
+	GrafanaVersion = "9.0.0"
 
 	// Paths
 	GrafanaDataPath         = "/var/lib/grafana"


### PR DESCRIPTION
We don't perform any changes to the grafana repo. We should be find calling to the never version and since grafana 9 was released a few days ago let's work towards it.