### PR TITLE
go-vet fix, reformatting, golang 1.19 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/api/v1beta1/grafanadashboard_types.go
+++ b/api/v1beta1/grafanadashboard_types.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"crypto/sha256"
 	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -109,7 +109,7 @@ func (in *GrafanaDatasource) Hash() string {
 		}
 
 		if in.Spec.Datasource.OrgID != nil {
-			hash.Write([]byte(string(*in.Spec.Datasource.OrgID)))
+			hash.Write([]byte(fmt.Sprint(*in.Spec.Datasource.OrgID)))
 		}
 	}
 

--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta1 contains API Schema definitions for the grafana v1beta1 API group
-//+kubebuilder:object:generate=true
-//+groupName=grafana.integreatly.org
+// +kubebuilder:object:generate=true
+// +groupName=grafana.integreatly.org
 package v1beta1
 
 import (

--- a/api/v1beta1/plugin_list.go
+++ b/api/v1beta1/plugin_list.go
@@ -3,9 +3,10 @@ package v1beta1
 import (
 	"crypto/sha256"
 	"fmt"
-	"github.com/blang/semver"
 	"io"
 	"strings"
+
+	"github.com/blang/semver"
 )
 
 type GrafanaPlugin struct {

--- a/api/v1beta1/typeoverrides.go
+++ b/api/v1beta1/typeoverrides.go
@@ -2,6 +2,8 @@ package v1beta1
 
 import (
 	"encoding/json"
+	"reflect"
+
 	v12 "github.com/openshift/api/route/v1"
 	"github.com/pkg/errors"
 	v13 "k8s.io/api/apps/v1"
@@ -9,7 +11,6 @@ import (
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"reflect"
 )
 
 // +kubebuilder:object:generate=true

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/model"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/go-logr/logr"
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	client2 "github.com/grafana-operator/grafana-operator-experimental/controllers/client"
@@ -30,7 +32,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
 )
 
 const (
@@ -185,15 +186,14 @@ func (r *GrafanaDashboardReconciler) onDashboardCreated(ctx context.Context, gra
 		Meta: grapi.DashboardMeta{
 			IsStarred: false,
 			Slug:      cr.Name,
-			//Folder:    ,
-			//URL:       "",
+			// Folder:    ,
+			// URL:       "",
 		},
 		Model: dashboardFromJson,
-		//Folder:    0,
+		// Folder:    0,
 		Overwrite: true,
 		Message:   "",
 	})
-
 	if err != nil {
 		return err
 	}

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/go-logr/logr"
 	client2 "github.com/grafana-operator/grafana-operator-experimental/controllers/client"
 	gapi "github.com/grafana/grafana-api-golang-client"
@@ -28,7 +30,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
 
 	grafanav1beta1 "github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 )
@@ -62,7 +63,6 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		Namespace: req.Namespace,
 		Name:      req.Name,
 	}, datasource)
-
 	if err != nil {
 		if errors.IsNotFound(err) {
 			err = r.onDatasourceDeleted(ctx, req.Namespace, req.Name)
@@ -116,7 +116,6 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	return ctrl.Result{RequeueAfter: RequeueDelaySuccess}, nil
-
 }
 
 func (r *GrafanaDatasourceReconciler) onDatasourceDeleted(ctx context.Context, namespace string, name string) error {

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -18,6 +18,9 @@ package controllers
 
 import (
 	"context"
+	"reflect"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/metrics"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/reconcilers"
@@ -26,8 +29,6 @@ import (
 	v12 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/discovery"
-	"reflect"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -59,7 +60,6 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	grafana := &grafanav1beta1.Grafana{}
 	err := r.Get(ctx, req.NamespacedName, grafana)
-
 	if err != nil {
 		if errors.IsNotFound(err) {
 			controllerLog.Info("grafana cr has been deleted", "name", req.NamespacedName)
@@ -72,7 +72,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	metrics.GrafanaReconciles.WithLabelValues(grafana.Name).Inc()
 
-	var finished = true
+	finished := true
 	stages := getInstallationStages()
 	nextStatus := grafana.Status.DeepCopy()
 	vars := &grafanav1beta1.OperatorReconcileVars{}

--- a/controllers/model/dashboard_resources.go
+++ b/controllers/model/dashboard_resources.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+
 	grafanav1beta1 "github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/model/grafana_resources.go
+++ b/controllers/model/grafana_resources.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+
 	grafanav1beta1 "github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	routev1 "github.com/openshift/api/route/v1"
 	v13 "k8s.io/api/apps/v1"

--- a/controllers/reconcilers/grafana/admin_secret_reconciler.go
+++ b/controllers/reconcilers/grafana/admin_secret_reconciler.go
@@ -2,13 +2,14 @@ package grafana
 
 import (
 	"context"
+	"os"
+
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/config"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/model"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/reconcilers"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -29,7 +30,6 @@ func (r *AdminSecretReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafa
 		secret.Data = getData(cr, secret)
 		return nil
 	})
-
 	if err != nil {
 		return v1beta1.OperatorStageResultFailed, err
 	}

--- a/controllers/reconcilers/grafana/complete_reconciler.go
+++ b/controllers/reconcilers/grafana/complete_reconciler.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"context"
+
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/reconcilers"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/controllers/reconcilers/grafana/config_reconciler.go
+++ b/controllers/reconcilers/grafana/config_reconciler.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"context"
+
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/config"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/model"
@@ -36,7 +37,6 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, s
 		configMap.Data["grafana.ini"] = config
 		return nil
 	})
-
 	if err != nil {
 		return v1beta1.OperatorStageResultFailed, err
 	}

--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"context"
 	"fmt"
+
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	config2 "github.com/grafana-operator/grafana-operator-experimental/controllers/config"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/model"
@@ -46,7 +47,6 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafan
 		deployment.Spec = getDeploymentSpec(cr, deployment.Name, scheme, vars)
 		return v1beta1.Merge(deployment, cr.Spec.Deployment)
 	})
-
 	if err != nil {
 		return v1beta1.OperatorStageResultFailed, err
 	}
@@ -133,7 +133,7 @@ func getContainers(cr *v1beta1.Grafana, scheme *runtime.Scheme, vars *v1beta1.Op
 	plugins := model.GetPluginsConfigMap(cr, scheme)
 
 	// env var to restart containers if plugins change
-	var t = true
+	t := true
 	var envVars []v1.EnvVar
 	envVars = append(envVars, v1.EnvVar{
 		Name: "PLUGINS_HASH",
@@ -204,7 +204,8 @@ func getContainers(cr *v1beta1.Grafana, scheme *runtime.Scheme, vars *v1beta1.Op
 					},
 					Key: config2.GrafanaAdminPasswordEnvVar,
 				},
-			}})
+			},
+		})
 	}
 
 	return containers

--- a/controllers/reconcilers/grafana/grafana_service_reconciler.go
+++ b/controllers/reconcilers/grafana/grafana_service_reconciler.go
@@ -3,6 +3,8 @@ package grafana
 import (
 	"context"
 	"fmt"
+	"strconv"
+
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/config"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/model"
@@ -13,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strconv"
 )
 
 type ServiceReconciler struct {
@@ -41,7 +42,6 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 		}
 		return v1beta1.Merge(service, cr.Spec.Service)
 	})
-
 	if err != nil {
 		return v1beta1.OperatorStageResultFailed, err
 	}

--- a/controllers/reconcilers/grafana/ingress_reconciler.go
+++ b/controllers/reconcilers/grafana/ingress_reconciler.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"context"
 	"fmt"
+
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/model"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/reconcilers"
@@ -57,7 +58,6 @@ func (r *IngressReconciler) reconcileIngress(ctx context.Context, cr *v1beta1.Gr
 		ingress.Spec = getIngressSpec(cr, scheme)
 		return v1beta1.Merge(ingress, cr.Spec.Ingress)
 	})
-
 	if err != nil {
 		return v1beta1.OperatorStageResultFailed, err
 	}
@@ -84,7 +84,6 @@ func (r *IngressReconciler) reconcileRoute(ctx context.Context, cr *v1beta1.Graf
 		err := v1beta1.Merge(route, cr.Spec.Route)
 		return err
 	})
-
 	if err != nil {
 		return v1beta1.OperatorStageResultFailed, err
 	}

--- a/controllers/reconcilers/grafana/plugins_reconciler.go
+++ b/controllers/reconcilers/grafana/plugins_reconciler.go
@@ -3,6 +3,7 @@ package grafana
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/model"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/reconcilers"

--- a/controllers/reconcilers/grafana/pvc_reconciler.go
+++ b/controllers/reconcilers/grafana/pvc_reconciler.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"context"
+
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/model"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/reconcilers"
@@ -33,7 +34,6 @@ func (r *PvcReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, stat
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, pvc, func() error {
 		return v1beta1.Merge(pvc, cr.Spec.PersistentVolumeClaim)
 	})
-
 	if err != nil {
 		return v1beta1.OperatorStageResultFailed, err
 	}

--- a/controllers/reconcilers/grafana/service_account_reconciler.go
+++ b/controllers/reconcilers/grafana/service_account_reconciler.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"context"
+
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/model"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/reconcilers"
@@ -26,7 +27,6 @@ func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, cr *v1beta1.Gr
 	_, err := controllerutil.CreateOrUpdate(ctx, r.client, sa, func() error {
 		return v1beta1.Merge(sa, cr.Spec.ServiceAccount)
 	})
-
 	if err != nil {
 		return v1beta1.OperatorStageResultFailed, err
 	}

--- a/controllers/reconcilers/reconciler.go
+++ b/controllers/reconcilers/reconciler.go
@@ -2,6 +2,7 @@ package reconcilers
 
 import (
 	"context"
+
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -37,9 +37,11 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -73,7 +75,6 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
 }, 60)
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
- Dockerfile:
  - Bumped golang version to 1.19;
  - Removed references to OS, so the same Dockerfile can be used for M1;
- Fixed a go vet complaint;
- Reformatted code with gofumpt.