### PR TITLE
feat: reduce the number of kube api requests

### DIFF
--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -87,6 +87,9 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if len(instances.Items) == 0 {
 		controllerLog.Info("no matching instances found for dashboard", "dashboard", dashboard.Name, "namespace", dashboard.Namespace)
+
+		// TODO when a label selector has been updated to no longer match any Grafana instances, should we delete the dashboard from those instances?
+		return ctrl.Result{Requeue: false}, nil
 	}
 
 	controllerLog.Info("found matching Grafana instances for dashboard", "count", len(instances.Items))
@@ -220,11 +223,11 @@ func (r *GrafanaDashboardReconciler) UpdateStatus(ctx context.Context, cr *v1bet
 }
 
 func (r *GrafanaDashboardReconciler) Exists(client *grapi.Client, cr *v1beta1.GrafanaDashboard) (bool, error) {
-	dashbaords, err := client.Dashboards()
+	dashboards, err := client.Dashboards()
 	if err != nil {
 		return false, err
 	}
-	for _, dashboard := range dashbaords {
+	for _, dashboard := range dashboards {
 		if dashboard.UID == string(cr.UID) {
 			return true, nil
 		}

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -127,8 +127,7 @@ func (r *GrafanaReconciler) updateStatus(cr *grafanav1beta1.Grafana, nextStatus 
 	}
 
 	return ctrl.Result{
-		Requeue:      false,
-		RequeueAfter: RequeueDelaySuccess,
+		Requeue: false,
 	}, nil
 }
 

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -19,9 +19,17 @@ var (
 		Name:      "failed_reconciles",
 		Help:      "failed reconciles per Grafana instance and stage",
 	}, []string{"instance_name", "stage"})
+
+	GrafanaApiRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "grafana_operator",
+		Subsystem: "grafana_api",
+		Name:      "requests",
+		Help:      "requests against the grafana api per instance",
+	}, []string{"instance_name", "path", "method", "status"})
 )
 
 func init() {
 	metrics.Registry.MustRegister(GrafanaReconciles)
 	metrics.Registry.MustRegister(GrafanaFailedReconciles)
+	metrics.Registry.MustRegister(GrafanaApiRequests)
 }


### PR DESCRIPTION
Reduced the number of Kuberbetes API requests by not reconciling Grafana CRs continuously (every 10 seconds). I think this is unnecessary, changes to the CR will be detected anyway.

Also expose metrics about the Grafana API requests.