### PR TITLE
fix: nil pointer dereference, incorrect url for svc, and other fixes

### DIFF
--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -36,6 +36,7 @@ type GrafanaDatasourceInternal struct {
 	IsDefault     *bool  `json:"isDefault,omitempty"`
 	BasicAuth     *bool  `json:"basicAuth,omitempty"`
 	BasicAuthUser string `json:"basicAuthUser,omitempty"`
+	Editable      *bool  `json:"editable,omitempty"`
 
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
@@ -111,6 +112,10 @@ func (in *GrafanaDatasource) Hash() string {
 
 		if in.Spec.Datasource.OrgID != nil {
 			hash.Write([]byte(fmt.Sprint(*in.Spec.Datasource.OrgID)))
+		}
+
+		if in.Spec.Datasource.Editable != nil && *in.Spec.Datasource.Editable {
+			hash.Write([]byte("_"))
 		}
 	}
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -319,6 +319,11 @@ func (in *GrafanaDatasourceInternal) DeepCopyInto(out *GrafanaDatasourceInternal
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Editable != nil {
+		in, out := &in.Editable, &out.Editable
+		*out = new(bool)
+		**out = **in
+	}
 	if in.JSONData != nil {
 		in, out := &in.JSONData, &out.JSONData
 		*out = make(json.RawMessage, len(*in))

--- a/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
@@ -38,6 +38,8 @@ spec:
                     type: string
                   database:
                     type: string
+                  editable:
+                    type: boolean
                   isDefault:
                     type: boolean
                   jsonData:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: grafana-operator-experimental-system
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: grafana-operator-experimental-
+namePrefix: grafana-operator-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/grafana.integreatly.org_grafanadatasources.yaml
+++ b/config/grafana.integreatly.org_grafanadatasources.yaml
@@ -46,6 +46,8 @@ spec:
                     type: string
                   database:
                     type: string
+                  editable:
+                    type: boolean
                   isDefault:
                     type: boolean
                   jsonData:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,7 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/config/samples/grafana_v1beta1_grafanadatasource.yaml
+++ b/config/samples/grafana_v1beta1_grafanadatasource.yaml
@@ -15,8 +15,7 @@ spec:
     access: proxy
     url: http://prometheus-service:9090
     isDefault: true
-    version: 1
-    editable: true
     jsonData:
       'tlsSkipVerify': true
       'timeInterval': "5s"
+    editable: true

--- a/controllers/client/grafana_client.go
+++ b/controllers/client/grafana_client.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"github.com/grafana-operator/grafana-operator-experimental/controllers/metrics"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/grafana-operator/grafana-operator-experimental/controllers/metrics"
 
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/config"
@@ -37,12 +38,14 @@ func newInstrumentedRoundTripper(instanceName string) http.RoundTripper {
 
 func (in *instrumentedRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	resp, err := in.wrapped.RoundTrip(r)
-	metrics.GrafanaApiRequests.WithLabelValues(
-		in.instanceName,
-		r.URL.Path,
-		r.Method,
-		strconv.Itoa(resp.StatusCode)).
-		Inc()
+	if resp != nil {
+		metrics.GrafanaApiRequests.WithLabelValues(
+			in.instanceName,
+			r.URL.Path,
+			r.Method,
+			strconv.Itoa(resp.StatusCode)).
+			Inc()
+	}
 	return resp, err
 }
 

--- a/controllers/config/operator_constants.go
+++ b/controllers/config/operator_constants.go
@@ -18,8 +18,9 @@ const (
 	GrafanaPluginsEnvVar       = "GF_INSTALL_PLUGINS"
 
 	// Networking
-	GrafanaHttpPort     int = 3000
-	GrafanaHttpPortName     = "grafana"
+	GrafanaHttpPort       int = 3000
+	GrafanaHttpPortName       = "grafana"
+	GrafanaServerProtocol     = "http"
 
 	// Data storage
 	GrafanaProvisionPluginVolumeName    = "grafana-provision-plugins"

--- a/controllers/config/operator_constants.go
+++ b/controllers/config/operator_constants.go
@@ -3,7 +3,7 @@ package config
 const (
 	// Grafana
 	GrafanaImage   = "docker.io/grafana/grafana"
-	GrafanaVersion = "9.0.0"
+	GrafanaVersion = "9.1.6"
 
 	// Paths
 	GrafanaDataPath         = "/var/lib/grafana"

--- a/controllers/reconcilers/grafana/grafana_service_reconciler.go
+++ b/controllers/reconcilers/grafana/grafana_service_reconciler.go
@@ -48,7 +48,12 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 
 	// try to assign the admin url
 	if !cr.PreferIngress() {
-		status.AdminUrl = fmt.Sprintf("%v.%v.svc.cluster.local:%d", service.Name, cr.Namespace,
+		protocol := "http"
+		if cr.Spec.Config["server"] != nil && cr.Spec.Config["server"]["protocol"] != "" {
+			protocol = cr.Spec.Config["server"]["protocol"]
+		}
+
+		status.AdminUrl = fmt.Sprintf("%v://%v.%v.svc.cluster.local:%d", protocol, service.Name, cr.Namespace,
 			int32(GetGrafanaPort(cr)))
 	}
 

--- a/controllers/reconcilers/grafana/grafana_service_reconciler.go
+++ b/controllers/reconcilers/grafana/grafana_service_reconciler.go
@@ -48,16 +48,18 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, cr *v1beta1.Grafana, 
 
 	// try to assign the admin url
 	if !cr.PreferIngress() {
-		protocol := "http"
-		if cr.Spec.Config["server"] != nil && cr.Spec.Config["server"]["protocol"] != "" {
-			protocol = cr.Spec.Config["server"]["protocol"]
-		}
-
-		status.AdminUrl = fmt.Sprintf("%v://%v.%v.svc.cluster.local:%d", protocol, service.Name, cr.Namespace,
+		status.AdminUrl = fmt.Sprintf("%v://%v.%v.svc.cluster.local:%d", getGrafanaServerProtocol(cr), service.Name, cr.Namespace,
 			int32(GetGrafanaPort(cr)))
 	}
 
 	return v1beta1.OperatorStageResultSuccess, nil
+}
+
+func getGrafanaServerProtocol(cr *v1beta1.Grafana) string {
+	if cr.Spec.Config != nil && cr.Spec.Config["server"] != nil && cr.Spec.Config["server"]["protocol"] != "" {
+		return cr.Spec.Config["server"]["protocol"]
+	}
+	return config.GrafanaServerProtocol
 }
 
 func GetGrafanaPort(cr *v1beta1.Grafana) int {

--- a/controllers/reconcilers/grafana/grafana_service_reconciler_test.go
+++ b/controllers/reconcilers/grafana/grafana_service_reconciler_test.go
@@ -1,0 +1,86 @@
+package grafana
+
+import (
+	"testing"
+
+	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
+	"github.com/grafana-operator/grafana-operator-experimental/controllers/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getGrafanaServerProtocol(t *testing.T) {
+	tests := []struct {
+		name string
+		cr   *v1beta1.Grafana
+		want string
+	}{
+		{
+			name: "Config nil",
+			cr: &v1beta1.Grafana{
+				Spec: v1beta1.GrafanaSpec{
+					Config: nil,
+				},
+			},
+			want: config.GrafanaServerProtocol,
+		},
+		{
+			name: "Server nil",
+			cr: &v1beta1.Grafana{
+				Spec: v1beta1.GrafanaSpec{
+					Config: map[string]map[string]string{
+						"server": nil,
+					},
+				},
+			},
+			want: config.GrafanaServerProtocol,
+		},
+		{
+			name: "Server protocol empty",
+			cr: &v1beta1.Grafana{
+				Spec: v1beta1.GrafanaSpec{
+					Config: map[string]map[string]string{
+						"server": {
+							"protocol": "",
+						},
+					},
+				},
+			},
+			want: config.GrafanaServerProtocol,
+		},
+		{
+			name: "Server protocol http",
+			cr: &v1beta1.Grafana{
+				Spec: v1beta1.GrafanaSpec{
+					Config: map[string]map[string]string{
+						"server": {
+							"protocol": "http",
+						},
+					},
+				},
+			},
+			want: config.GrafanaServerProtocol,
+		},
+		{
+			name: "Server protocol https",
+			cr: &v1beta1.Grafana{
+				Spec: v1beta1.GrafanaSpec{
+					Config: map[string]map[string]string{
+						"server": {
+							"protocol": "https",
+						},
+					},
+				},
+			},
+			want: "https",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := tt.want
+			got := getGrafanaServerProtocol(tt.cr)
+
+			assert.Equal(t, want, got)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,11 @@ require (
 )
 
 require (
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.0 // indirect
+)
+
+require (
 	cloud.google.com/go v0.81.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.18 // indirect
@@ -67,7 +72,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.23.1 // indirect
 	k8s.io/component-base v0.23.1 // indirect
 	k8s.io/klog/v2 v2.40.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,16 +11,14 @@ require (
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
+	github.com/stretchr/testify v1.8.0
 	k8s.io/api v0.23.1
 	k8s.io/apimachinery v0.23.1
 	k8s.io/client-go v0.23.1
 	sigs.k8s.io/controller-runtime v0.11.0
 )
 
-require (
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.8.0 // indirect
-)
+require github.com/pmezard/go-difflib v1.0.0 // indirect
 
 require (
 	cloud.google.com/go v0.81.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -463,7 +463,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
@@ -937,7 +936,6 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -457,6 +457,7 @@ github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -464,6 +465,9 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -935,6 +939,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
- With `preferIngress: false`, the operator couldn't reach grafana instance, because the former was generating an incorrect URL (missing protocol). Example of the error:
`grafana-operator-exp-controller-manager-6575764768-gn688 manager 1.6639349543764849e+09 ERROR   controller.grafanadashboard     error reconciling dashboard  {"reconciler group": "grafana.integreatly.org", "reconciler kind": "GrafanaDashboard", "name": "grafanadashboard-sample-3", "namespace": "grafana-operator-experimental-system", "dashboard": "grafanadashboard-sample-3", "grafana": "grafana-a", "error": "Post \"grafana-a-service.grafana-operator-experimental-system.svc.cluster.local:3000\": unsupported protocol scheme \"grafana-a-service.grafana-operator-experimental-system.svc.cluster.local\""}`'
- Also, when the operator is unable to reach grafana instance, resp is nil, so there's nil pointer dereference in `nc (in *instrumentedRoundTripper) RoundTrip`, fixed that;
- Shortened `namePrefix` in kustomize, because service name was exceeding name length limits;
- Fixed example for Datasource + added support for `editable` field:
  - Though, the field doesn't actually impact datasource. Even when I tried to submit a datasource via curl, grafana would always respond with `readOnly: false`, so I guess it's not supposed to work through API or it's a bug in grafana. So, maybe it should have rather been completely removed from the operator;
- Changed `imagePullPolicy` to simplify development (I push images under the same tag).
- Bumped version of grafana image from `9.0.0` to `9.1.6` (latest).