### PR TITLE
feature: add audit lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ vendor
 *~
 
 .vscode/
+
+labs/audit/kube-apiserver-audit.log
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ vendor
 *~
 
 .vscode/
-
-labs/audit/kube-apiserver-audit.log
 .DS_Store
+
+# Audit lab
+kube-apiserver-audit.log

--- a/labs/audit/README.md
+++ b/labs/audit/README.md
@@ -7,6 +7,7 @@ The goal of the lab is to get stats for interactions with kube-apiserver.
 - bash
 - docker
 - jq
+- kind
 
 ## Instructions
 

--- a/labs/audit/README.md
+++ b/labs/audit/README.md
@@ -30,7 +30,7 @@ kubectl apply -f config/samples/grafana_v1beta1_grafanadatasource.yaml
 
 NOTE: at the time of writing, kubebuilder lacks full definition for cluster-scope RBAC, you need to take care of that.
 
-Collect stats:
+Collect stats after a few minutes:
 
 ```shell
 ./collect-audit-stats.sh

--- a/labs/audit/README.md
+++ b/labs/audit/README.md
@@ -1,0 +1,46 @@
+# Audit stats lab
+
+The goal of the lab is to get stats for interactions with kube-apiserver.
+
+## Technical requirements
+
+- bash
+- docker
+- jq
+
+## Instructions
+
+Create kind cluster:
+
+```shell
+kind create cluster --config kind-config.yaml
+```
+
+Deploy the operator and related resources from the root of the git folder:
+
+```shell
+export IMG=<XXX>
+make install
+make deploy
+kubectl apply -f config/samples/grafana_v1beta1_grafana.yaml
+kubectl apply -f config/samples/grafana_v1beta1_grafanadashboard.yaml
+kubectl apply -f config/samples/grafana_v1beta1_grafanadatasource.yaml
+```
+
+NOTE: at the time of writing, kubebuilder lacks full definition for cluster-scope RBAC, you need to take care of that.
+
+Collect stats:
+
+```shell
+./collect-audit-stats.sh
+```
+
+Example:
+
+```shell
+./collect-audit-stats.sh
+   3 "get - /api/v1/namespaces/grafana-operator-experimental-system/configmaps/f75f3bba.integreatly.org"
+   6 "get - /apis/coordination.k8s.io/v1/namespaces/grafana-operator-experimental-system/leases/f75f3bba.integreatly.org"
+   3 "update - /api/v1/namespaces/grafana-operator-experimental-system/configmaps/f75f3bba.integreatly.org"
+   3 "update - /apis/coordination.k8s.io/v1/namespaces/grafana-operator-experimental-system/leases/f75f3bba.integreatly.org"
+```

--- a/labs/audit/audit-policy.yaml
+++ b/labs/audit/audit-policy.yaml
@@ -1,0 +1,5 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: Metadata
+    namespaces: ["grafana-operator-experimental-system"]

--- a/labs/audit/collect-audit-stats.sh
+++ b/labs/audit/collect-audit-stats.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker cp kind-control-plane:/var/log/kubernetes/kube-apiserver-audit.log .
+docker exec kind-control-plane truncate -s 0 /var/log/kubernetes/kube-apiserver-audit.log
+grep RequestReceived kube-apiserver-audit.log | grep "system:serviceaccount:grafana-operator-experimental-system:grafana-operator-controller-manager" | jq '. | { verb, requestURI } | join(" - ")' | sort | uniq -c

--- a/labs/audit/kind-config.yaml
+++ b/labs/audit/kind-config.yaml
@@ -1,0 +1,30 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+        # enable auditing flags on the API server
+        extraArgs:
+          audit-log-path: /var/log/kubernetes/kube-apiserver-audit.log
+          audit-log-maxsize: "100"
+          audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+        # mount new files / directories on the control plane
+        extraVolumes:
+          - name: audit-policies
+            hostPath: /etc/kubernetes/policies
+            mountPath: /etc/kubernetes/policies
+            readOnly: true
+            pathType: "DirectoryOrCreate"
+          - name: "audit-logs"
+            hostPath: "/var/log/kubernetes"
+            mountPath: "/var/log/kubernetes"
+            readOnly: false
+            pathType: DirectoryOrCreate
+  # mount the local file on the control plane
+  extraMounts:
+  - hostPath: ./audit-policy.yaml
+    containerPath: /etc/kubernetes/policies/audit-policy.yaml
+    readOnly: true


### PR DESCRIPTION
A simple lab that helps to keep track of number of API requests sent to kube-apiserver.

Things that we can potentially decide to change now or at some point later in time:

- Cluster name (`kind`) by default. I don't have multiple cluster at a time, so the default name is just fine for me. If that's not your case, feel free to suggest something else;
- Once RBAC issues are resolved (currently, kubebuilder generates roles with insufficient permissions), we can integrate the lab into Makefile (or something much simpler to use like Taskfile);
- It can also be part of an acceptance workflow if needed.

In support of https://github.com/grafana-operator/grafana-operator-experimental/issues/20