### PR TITLE
fix panic in WriteIni, tiny code style fixes

### DIFF
--- a/controllers/config/grafana_ini.go
+++ b/controllers/config/grafana_ini.go
@@ -9,6 +9,10 @@ import (
 )
 
 func WriteIni(cfg map[string]map[string]string) (string, string) {
+	if cfg == nil {
+		cfg = make(map[string]map[string]string)
+	}
+
 	if cfg["paths"] == nil {
 		cfg["paths"] = make(map[string]string)
 	}

--- a/controllers/controller_shared.go
+++ b/controllers/controller_shared.go
@@ -43,7 +43,7 @@ func ReconcilePlugins(ctx context.Context, k8sClient client.Client, scheme *runt
 		pluginsConfigMap.BinaryData = make(map[string][]byte)
 	}
 
-	if bytes.Compare(val, pluginsConfigMap.BinaryData[resource]) != 0 {
+	if !bytes.Equal(val, pluginsConfigMap.BinaryData[resource]) {
 		pluginsConfigMap.BinaryData[resource] = val
 		return k8sClient.Update(ctx, pluginsConfigMap)
 	}

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -174,6 +174,9 @@ func (r *GrafanaDashboardReconciler) onDashboardCreated(ctx context.Context, gra
 
 	// update/create the dashboard if it doesn't exist in the instance or has been changed
 	exists, err := r.Exists(grafanaClient, cr)
+	if err != nil {
+		return err
+	}
 	if exists && cr.Unchanged() {
 		return nil
 	}

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -193,7 +193,7 @@ func (r *GrafanaDatasourceReconciler) onDatasourceCreated(ctx context.Context, g
 		if err != nil && !strings.Contains(err.Error(), "status: 409") {
 			return err
 		}
-	} else if cr.Unchanged() == false {
+	} else if !cr.Unchanged() {
 		err := grafanaClient.UpdateDataSourceFromRawData(*id, datasourceBytes)
 		if err != nil {
 			return err

--- a/controllers/reconcilers/grafana/deployment_reconciler.go
+++ b/controllers/reconcilers/grafana/deployment_reconciler.go
@@ -127,9 +127,8 @@ func getVolumeMounts(cr *v1beta1.Grafana, scheme *runtime.Scheme) []v1.VolumeMou
 
 func getContainers(cr *v1beta1.Grafana, scheme *runtime.Scheme, vars *v1beta1.OperatorReconcileVars) []v1.Container { // nolint
 	var containers []v1.Container // nolint
-	var image string
 
-	image = fmt.Sprintf("%s:%s", config2.GrafanaImage, config2.GrafanaVersion)
+	image := fmt.Sprintf("%s:%s", config2.GrafanaImage, config2.GrafanaVersion)
 	plugins := model.GetPluginsConfigMap(cr, scheme)
 
 	// env var to restart containers if plugins change


### PR DESCRIPTION
1. Fix panic in `WriteIni` if spec is nil (`assignment to entry in nil map`):

```
---
apiVersion: grafana.integreatly.org/v1beta1
kind: Grafana
metadata:
  name: grafana-a
  labels:
    dashboards: "grafana-a"
spec:
```

2. A few tiny fixes reported by golangci-lint.