### PR TITLE
fix: properly generate adminURL for Ingresses, requeue grafana reconciliation

### DIFF
--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -102,9 +102,7 @@ func (r *GrafanaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		nextStatus.StageStatus = status
 
 		if status != grafanav1beta1.OperatorStageResultSuccess {
-			controllerLog.Info("stage in progress", "stage", stage)
-			finished = false
-			break
+			return ctrl.Result{RequeueAfter: RequeueDelayError}, nil
 		}
 	}
 

--- a/controllers/reconcilers/grafana/ingress_reconciler.go
+++ b/controllers/reconcilers/grafana/ingress_reconciler.go
@@ -67,7 +67,7 @@ func (r *IngressReconciler) reconcileIngress(ctx context.Context, cr *v1beta1.Gr
 		adminURL := r.getIngressAdminURL(ingress)
 
 		if len(ingress.Status.LoadBalancer.Ingress) == 0 {
-			return v1beta1.OperatorStageResultFailed, fmt.Errorf("ingress is not ready yet")
+			return v1beta1.OperatorStageResultInProgress, fmt.Errorf("ingress is not ready yet")
 		}
 
 		if adminURL == "" {

--- a/controllers/reconcilers/grafana/ingress_reconciler.go
+++ b/controllers/reconcilers/grafana/ingress_reconciler.go
@@ -64,13 +64,17 @@ func (r *IngressReconciler) reconcileIngress(ctx context.Context, cr *v1beta1.Gr
 
 	// try to assign the admin url
 	if cr.PreferIngress() {
-		if len(ingress.Status.LoadBalancer.Ingress) > 0 {
-			ingress := ingress.Status.LoadBalancer.Ingress[0]
-			if ingress.Hostname != "" {
-				status.AdminUrl = fmt.Sprintf("https://%v", ingress.Hostname)
-			}
-			status.AdminUrl = fmt.Sprintf("https://%v", ingress.IP)
+		adminURL := r.getIngressAdminURL(ingress)
+
+		if len(ingress.Status.LoadBalancer.Ingress) == 0 {
+			return v1beta1.OperatorStageResultFailed, fmt.Errorf("ingress is not ready yet")
 		}
+
+		if adminURL == "" {
+			return v1beta1.OperatorStageResultFailed, fmt.Errorf("ingress spec is incomplete")
+		}
+
+		status.AdminUrl = adminURL
 	}
 
 	return v1beta1.OperatorStageResultSuccess, nil
@@ -96,6 +100,42 @@ func (r *IngressReconciler) reconcileRoute(ctx context.Context, cr *v1beta1.Graf
 	}
 
 	return v1beta1.OperatorStageResultSuccess, nil
+}
+
+// getIngressAdminURL returns the first valid URL (Host field is set) from the ingress spec
+func (r *IngressReconciler) getIngressAdminURL(ingress *v1.Ingress) string {
+	if ingress == nil {
+		return ""
+	}
+
+	protocol := "http"
+	var hostname string
+	var adminURL string
+
+	// An ingress rule might not have the field Host specified, better not to consider such rules
+	for _, rule := range ingress.Spec.Rules {
+		if rule.Host != "" {
+			hostname = rule.Host
+			break
+		}
+	}
+
+	// If we can find the target host in any of the IngressTLS, then we should use https protocol
+	for _, tls := range ingress.Spec.TLS {
+		for _, h := range tls.Hosts {
+			if h == hostname {
+				protocol = "https"
+				break
+			}
+		}
+	}
+
+	// adminUrl should not be empty only in case hostname is found, otherwise we'll have broken URLs like "http://"
+	if hostname != "" {
+		adminURL = fmt.Sprintf("%v://%v", protocol, hostname)
+	}
+
+	return adminURL
 }
 
 func (r *IngressReconciler) isOpenShift() (bool, error) {


### PR DESCRIPTION
The PR contains multiple fixes for `adminURL` synchronisation:
- issue: operator can generate broken adminURLs in case IP / Host is missing (e.g. `http://`);
  - fix: always make sure hostname is set;
- issue: host is taken from `Status.LoadBalancer`, which will not contain the actual ingress host;
  - fix: use hosts instead;
- issue: operator always assumes https;
  - fix: if we have a matching host in tls settings, use https, for other cases - http;
- issue: if there's an error during Grafana reconciliation, the process gets stuck until there's any change in grafana spec;
  - fix: requeue grafana in case of errors;

I think it'll close the following issues:

Closes: #40 
Closes: #41