### PR TITLE
Use signal.NotifyContext for easier stop solution

### DIFF
--- a/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadashboards.yaml
@@ -29,6 +29,8 @@ spec:
             properties:
               contentCacheDuration:
                 type: string
+              folder:
+                type: string
               instanceSelector:
                 properties:
                   matchExpressions:

--- a/config/grafana.integreatly.org_grafanadashboards.yaml
+++ b/config/grafana.integreatly.org_grafanadashboards.yaml
@@ -38,6 +38,9 @@ spec:
               contentCacheDuration:
                 description: Cache duration for dashboards fetched from URLs
                 type: string
+              folder:
+                description: folder assignment for dashboard
+                type: string
               instanceSelector:
                 description: selects Grafanas for import
                 properties:

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -23,6 +23,10 @@ import (
 	"fmt"
 	"strings"
 
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	client2 "github.com/grafana-operator/grafana-operator-experimental/controllers/client"
@@ -32,12 +36,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
-	"net/http"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strconv"
-	"time"
 )
 
 const (
@@ -460,7 +461,7 @@ func (r *GrafanaDashboardReconciler) DeleteFolderIfEmpty(client *grapi.Client,
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *GrafanaDashboardReconciler) SetupWithManager(mgr ctrl.Manager, stop chan bool) error {
+func (r *GrafanaDashboardReconciler) SetupWithManager(mgr ctrl.Manager, ctx context.Context) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.GrafanaDashboard{}).
 		Complete(r)
@@ -474,10 +475,8 @@ func (r *GrafanaDashboardReconciler) SetupWithManager(mgr ctrl.Manager, stop cha
 		go func() {
 			for {
 				select {
-				case <-stop:
-					return
 				case <-time.After(d):
-					result, err := r.Reconcile(context.Background(), ctrl.Request{})
+					result, err := r.Reconcile(ctx, ctrl.Request{})
 					if err != nil {
 						r.Log.Error(err, "error synchronizing dashboards")
 						continue

--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -475,6 +475,8 @@ func (r *GrafanaDashboardReconciler) SetupWithManager(mgr ctrl.Manager, ctx cont
 		go func() {
 			for {
 				select {
+				case <-ctx.Done():
+					return
 				case <-time.After(d):
 					result, err := r.Reconcile(ctx, ctrl.Request{})
 					if err != nil {

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -336,6 +336,8 @@ func (r *GrafanaDatasourceReconciler) SetupWithManager(mgr ctrl.Manager, ctx con
 		go func() {
 			for {
 				select {
+				case <-ctx.Done():
+					return
 				case <-time.After(d):
 					result, err := r.Reconcile(ctx, ctrl.Request{})
 					if err != nil {

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/grafana-operator/grafana-operator-experimental/controllers/metrics"
 	"strings"
 	"time"
+
+	"github.com/grafana-operator/grafana-operator-experimental/controllers/metrics"
 
 	"github.com/go-logr/logr"
 	client2 "github.com/grafana-operator/grafana-operator-experimental/controllers/client"
@@ -321,7 +322,7 @@ func (r *GrafanaDatasourceReconciler) ExistingId(client *gapi.Client, cr *v1beta
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *GrafanaDatasourceReconciler) SetupWithManager(mgr ctrl.Manager, stop chan bool) error {
+func (r *GrafanaDatasourceReconciler) SetupWithManager(mgr ctrl.Manager, ctx context.Context) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.GrafanaDatasource{}).
 		Complete(r)
@@ -335,10 +336,8 @@ func (r *GrafanaDatasourceReconciler) SetupWithManager(mgr ctrl.Manager, stop ch
 		go func() {
 			for {
 				select {
-				case <-stop:
-					return
 				case <-time.After(d):
-					result, err := r.Reconcile(context.Background(), ctrl.Request{})
+					result, err := r.Reconcile(ctx, ctrl.Request{})
 					if err != nil {
 						r.Log.Error(err, "error synchronizing datasources")
 						continue

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -219,6 +219,8 @@ func (r *GrafanaFolderReconciler) SetupWithManager(mgr ctrl.Manager, ctx context
 		go func() {
 			for {
 				select {
+				case <-ctx.Done():
+					return
 				case <-time.After(d):
 					result, err := r.Reconcile(ctx, ctrl.Request{})
 					if err != nil {

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/go-logr/logr"
 	client2 "github.com/grafana-operator/grafana-operator-experimental/controllers/client"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers/metrics"
 	grapi "github.com/grafana/grafana-api-golang-client"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"strings"
-	"time"
 
 	"github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -204,7 +205,7 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *GrafanaFolderReconciler) SetupWithManager(mgr ctrl.Manager, stop chan bool) error {
+func (r *GrafanaFolderReconciler) SetupWithManager(mgr ctrl.Manager, ctx context.Context) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&grafanav1beta1.GrafanaFolder{}).
 		Complete(r)
@@ -218,10 +219,8 @@ func (r *GrafanaFolderReconciler) SetupWithManager(mgr ctrl.Manager, stop chan b
 		go func() {
 			for {
 				select {
-				case <-stop:
-					return
 				case <-time.After(d):
-					result, err := r.Reconcile(context.Background(), ctrl.Request{})
+					result, err := r.Reconcile(ctx, ctrl.Request{})
 					if err != nil {
 						r.Log.Error(err, "error synchronizing folders")
 						continue

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"syscall"
 
 	discovery2 "k8s.io/client-go/discovery"
 
@@ -79,7 +80,7 @@ func main() {
 		setupLog.Info("operator restricted to namespace", "namespace", namespace)
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE)
 	defer stop()
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/main.go
+++ b/main.go
@@ -143,4 +143,7 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+
+	<-ctx.Done()
+	setupLog.Info("SIGTERM request gotten, shutting down operator")
 }


### PR DESCRIPTION
Please ignore all the other changes, they are fixed by my editor.

The interesting part is that I deleted the stop channel and use signal.NotifyContext instead.

```.go
	stop := make(chan bool)
	sigs := make(chan os.Signal)
	signal.Notify(sigs, syscall.SIGTERM, syscall.SIGABRT, syscall.SIGINT)
	go func() {
		sig := <-sigs
		switch sig {
		case syscall.SIGTERM, syscall.SIGABRT, syscall.SIGINT:
			close(stop)
		}
	}()
```

And instead use:

```.go
	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
	defer stop()
```
