### PR TITLE
Adding deployment best practices to grafana instance

### DIFF
--- a/controllers/autodetect/main.go
+++ b/controllers/autodetect/main.go
@@ -1,0 +1,50 @@
+// Package autodetect is for auto-detecting traits from the environment (platform, APIs, ...).
+package autodetect
+
+import (
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+var _ AutoDetect = (*autoDetect)(nil)
+
+// AutoDetect provides an assortment of routines that auto-detect traits based on the runtime.
+type AutoDetect interface {
+	IsOpenshift() (bool, error)
+}
+
+type autoDetect struct {
+	dcl discovery.DiscoveryInterface
+}
+
+// New creates a new auto-detection worker, using the given client when talking to the current cluster.
+func New(restConfig *rest.Config) (AutoDetect, error) {
+	dcl, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		// it's pretty much impossible to get into this problem, as most of the
+		// code branches from the previous call just won't fail at all,
+		// but let's handle this error anyway...
+		return nil, err
+	}
+
+	return &autoDetect{
+		dcl: dcl,
+	}, nil
+}
+
+// Platform returns the detected platform this operator is running on. Possible values: Kubernetes, OpenShift.
+func (a *autoDetect) IsOpenshift() (bool, error) {
+	apiList, err := a.dcl.ServerGroups()
+	if err != nil {
+		return false, err
+	}
+
+	apiGroups := apiList.Groups
+	for i := 0; i < len(apiGroups); i++ {
+		if apiGroups[i].Name == "route.openshift.io" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/controllers/autodetect/main_test.go
+++ b/controllers/autodetect/main_test.go
@@ -1,0 +1,57 @@
+package autodetect_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana-operator/grafana-operator-experimental/controllers/autodetect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+func TestDetectPlatformBasedOnAvailableAPIGroups(t *testing.T) {
+	for _, tt := range []struct {
+		apiGroupList *metav1.APIGroupList
+		expected     bool
+	}{
+		{
+			&metav1.APIGroupList{},
+			false,
+		},
+		{
+			&metav1.APIGroupList{
+				Groups: []metav1.APIGroup{
+					{
+						Name: "route.openshift.io",
+					},
+				},
+			},
+			true,
+		},
+	} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			output, err := json.Marshal(tt.apiGroupList)
+			require.NoError(t, err)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(output)
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		autoDetect, err := autodetect.New(&rest.Config{Host: server.URL})
+		require.NoError(t, err)
+
+		// test
+		plt, err := autoDetect.IsOpenshift()
+
+		// verify
+		assert.NoError(t, err)
+		assert.Equal(t, tt.expected, plt)
+	}
+}

--- a/controllers/grafana_controller.go
+++ b/controllers/grafana_controller.go
@@ -45,9 +45,10 @@ const (
 // GrafanaReconciler reconciles a Grafana object
 type GrafanaReconciler struct {
 	client.Client
-	Log       logr.Logger
-	Scheme    *runtime.Scheme
-	Discovery discovery.DiscoveryInterface
+	Log         logr.Logger
+	Scheme      *runtime.Scheme
+	Discovery   discovery.DiscoveryInterface
+	IsOpenShift bool
 }
 
 //+kubebuilder:rbac:groups=grafana.integreatly.org,resources=grafanas,verbs=get;list;watch;create;update;patch;delete
@@ -185,11 +186,11 @@ func (r *GrafanaReconciler) getReconcilerForStage(stage grafanav1beta1.OperatorS
 	case grafanav1beta1.OperatorStageService:
 		return grafana.NewServiceReconciler(r.Client)
 	case grafanav1beta1.OperatorStageIngress:
-		return grafana.NewIngressReconciler(r.Client, r.Discovery)
+		return grafana.NewIngressReconciler(r.Client, r.IsOpenShift)
 	case grafanav1beta1.OperatorStagePlugins:
 		return grafana.NewPluginsReconciler(r.Client)
 	case grafanav1beta1.OperatorStageDeployment:
-		return grafana.NewDeploymentReconciler(r.Client)
+		return grafana.NewDeploymentReconciler(r.Client, r.IsOpenShift)
 	case grafanav1beta1.OperatorStageComplete:
 		return grafana.NewCompleteReconciler()
 	default:

--- a/controllers/model/utils.go
+++ b/controllers/model/utils.go
@@ -29,3 +29,7 @@ func MergeAnnotations(requested map[string]string, existing map[string]string) m
 	}
 	return existing
 }
+
+func BoolPtr(b bool) *bool { return &b }
+
+func IntPtr(b int64) *int64 { return &b }

--- a/examples/grafana_deployment/README.md
+++ b/examples/grafana_deployment/README.md
@@ -1,0 +1,3 @@
+# Grafana deployment override
+
+A basic deployment of Grafana that overrides the existing readiness and securityContext.

--- a/examples/grafana_deployment/resources.yaml
+++ b/examples/grafana_deployment/resources.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  labels:
+    dashboards: "grafana"
+spec:
+  client:
+    preferIngress: true
+  config:
+    log:
+      mode: "console"
+    auth:
+      disable_login_form: "false"
+    security:
+      admin_user: root
+      admin_password: secret
+  deployment:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: grafana
+              securityContext:
+                allowPrivilegeEscalation: true
+                readOnlyRootFilesystem: false
+              readinessProbe:
+                failureThreshold: 3

--- a/examples/grafana_deployment/resources.yaml
+++ b/examples/grafana_deployment/resources.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     dashboards: "grafana"
 spec:
-  client:
-    preferIngress: true
   config:
     log:
       mode: "console"

--- a/main.go
+++ b/main.go
@@ -106,7 +106,8 @@ func main() {
 	}
 	isOpenShift, err := autodetect.IsOpenshift()
 	if err != nil {
-		setupLog.Error(err, "unable to check platform")
+		setupLog.Error(err, "unable to detect the platform")
+		os.Exit(1)
 	}
 
 	if err = (&controllers.GrafanaReconciler{

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 
 	grafanav1beta1 "github.com/grafana-operator/grafana-operator-experimental/api/v1beta1"
 	"github.com/grafana-operator/grafana-operator-experimental/controllers"
+	"github.com/grafana-operator/grafana-operator-experimental/controllers/autodetect"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -97,10 +98,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	restConfig := ctrl.GetConfigOrDie()
+	autodetect, err := autodetect.New(restConfig)
+	if err != nil {
+		setupLog.Error(err, "failed to setup auto-detect routine")
+		os.Exit(1)
+	}
+	isOpenShift, err := autodetect.IsOpenshift()
+	if err != nil {
+		setupLog.Error(err, "unable to check platform")
+	}
+
 	if err = (&controllers.GrafanaReconciler{
-		Client:    mgr.GetClient(),
-		Scheme:    mgr.GetScheme(),
-		Discovery: discovery2.NewDiscoveryClientForConfigOrDie(ctrl.GetConfigOrDie()),
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		IsOpenShift: isOpenShift,
+		Discovery:   discovery2.NewDiscoveryClientForConfigOrDie(ctrl.GetConfigOrDie()),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Grafana")
 		os.Exit(1)


### PR DESCRIPTION
These settings should be used as default in kubernetes.
We will get issues with it on OCP though, due to how `RunAsUser` is managed and OCP automatically gives all containers a random user to run on per namespace/project.

In general we need a good way of detecting if we are running on OCP.
Currently the one we are using now is: https://github.com/grafana-operator/grafana-operator-experimental/blob/d0fcdf279f9aefbd8e2175593a63e00abd51119b/controllers/reconcilers/grafana/ingress_reconciler.go#L101

But it's a bit painful.

When it's done it should hopefully solve: https://github.com/grafana-operator/grafana-operator-experimental/issues/7