### PR TITLE
fix: reconcile only when a stage is not finished

### DIFF
--- a/controllers/dashboard_controller.go
+++ b/controllers/dashboard_controller.go
@@ -161,24 +161,24 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if errors.IsNotFound(err) {
 			err = r.onDashboardDeleted(ctx, req.Namespace, req.Name)
 			if err != nil {
-				return ctrl.Result{RequeueAfter: RequeueDelayError}, err
+				return ctrl.Result{RequeueAfter: RequeueDelay}, err
 			}
 			return ctrl.Result{}, nil
 		}
 		controllerLog.Error(err, "error getting grafana dashboard cr")
-		return ctrl.Result{RequeueAfter: RequeueDelayError}, err
+		return ctrl.Result{RequeueAfter: RequeueDelay}, err
 	}
 
 	// skip dashboards without an instance selector
 	if dashboard.Spec.InstanceSelector == nil {
 		controllerLog.Info("no instance selector found for dashboard, nothing to do", "name", dashboard.Name, "namespace", dashboard.Namespace)
-		return ctrl.Result{RequeueAfter: RequeueDelayError}, nil
+		return ctrl.Result{RequeueAfter: RequeueDelay}, nil
 	}
 
 	instances, err := GetMatchingInstances(ctx, r.Client, dashboard.Spec.InstanceSelector)
 	if err != nil {
 		controllerLog.Error(err, "could not find matching instance", "name", dashboard.Name)
-		return ctrl.Result{RequeueAfter: RequeueDelayError}, err
+		return ctrl.Result{RequeueAfter: RequeueDelay}, err
 	}
 
 	if len(instances.Items) == 0 {
@@ -223,7 +223,7 @@ func (r *GrafanaDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{RequeueAfter: dashboard.GetResyncPeriod()}, nil
 	}
 
-	return ctrl.Result{RequeueAfter: RequeueDelayError}, nil
+	return ctrl.Result{RequeueAfter: RequeueDelay}, nil
 }
 
 func (r *GrafanaDashboardReconciler) onDashboardDeleted(ctx context.Context, namespace string, name string) error {

--- a/controllers/datasource_controller.go
+++ b/controllers/datasource_controller.go
@@ -156,23 +156,23 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if errors.IsNotFound(err) {
 			err = r.onDatasourceDeleted(ctx, req.Namespace, req.Name)
 			if err != nil {
-				return ctrl.Result{RequeueAfter: RequeueDelayError}, err
+				return ctrl.Result{RequeueAfter: RequeueDelay}, err
 			}
 			return ctrl.Result{}, nil
 		}
 		controllerLog.Error(err, "error getting grafana dashboard cr")
-		return ctrl.Result{RequeueAfter: RequeueDelayError}, err
+		return ctrl.Result{RequeueAfter: RequeueDelay}, err
 	}
 
 	if datasource.Spec.InstanceSelector == nil {
 		controllerLog.Info("no instance selector found for datasource, nothing to do", "name", datasource.Name, "namespace", datasource.Namespace)
-		return ctrl.Result{RequeueAfter: RequeueDelayError}, err
+		return ctrl.Result{RequeueAfter: RequeueDelay}, err
 	}
 
 	instances, err := GetMatchingInstances(ctx, r.Client, datasource.Spec.InstanceSelector)
 	if err != nil {
 		controllerLog.Error(err, "could not find matching instance", "name", datasource.Name)
-		return ctrl.Result{RequeueAfter: RequeueDelayError}, err
+		return ctrl.Result{RequeueAfter: RequeueDelay}, err
 	}
 
 	if len(instances.Items) == 0 {
@@ -213,7 +213,7 @@ func (r *GrafanaDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{RequeueAfter: datasource.GetResyncPeriod()}, nil
 	}
 
-	return ctrl.Result{RequeueAfter: RequeueDelayError}, nil
+	return ctrl.Result{RequeueAfter: RequeueDelay}, nil
 }
 
 func (r *GrafanaDatasourceReconciler) onDatasourceDeleted(ctx context.Context, namespace string, name string) error {

--- a/controllers/grafanafolder_controller.go
+++ b/controllers/grafanafolder_controller.go
@@ -161,23 +161,23 @@ func (r *GrafanaFolderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err != nil {
 		if errors.IsNotFound(err) {
 			if err := r.onFolderDeleted(ctx, req.Namespace, req.Name); err != nil {
-				return ctrl.Result{RequeueAfter: RequeueDelayError}, err
+				return ctrl.Result{RequeueAfter: RequeueDelay}, err
 			}
 			return ctrl.Result{}, nil
 		}
 		controllerLog.Error(err, "error getting grafana folder cr")
-		return ctrl.Result{RequeueAfter: RequeueDelayError}, err
+		return ctrl.Result{RequeueAfter: RequeueDelay}, err
 	}
 
 	if folder.Spec.InstanceSelector == nil {
 		controllerLog.Info("no instance selector found for folder, nothing to do", "name", folder.Name, "namespace", folder.Namespace)
-		return ctrl.Result{RequeueAfter: RequeueDelayError}, nil
+		return ctrl.Result{RequeueAfter: RequeueDelay}, nil
 	}
 
 	instances, err := GetMatchingInstances(ctx, r.Client, folder.Spec.InstanceSelector)
 	if err != nil {
 		controllerLog.Error(err, "could not find matching instances", "name", folder.Name)
-		return ctrl.Result{RequeueAfter: RequeueDelayError}, err
+		return ctrl.Result{RequeueAfter: RequeueDelay}, err
 	}
 	// your logic here
 


### PR DESCRIPTION
Reconciler only when a stage either failed or is not finished yet, while still making sure that the status is updated with an error message if needed:

1. If an error occurs or a reconciler returns `in progress`, the grafana controller will retry in 10 seconds.
2. The status is updated only if there are actual changes (e.g. an error message). This was already the case.
3. If reconcile was successful and if there was no change in status, the status is not updated.