### PR TITLE
Remove PreserveUnknownFields from CRD

### DIFF
--- a/api/v1beta1/grafanadatasource_types.go
+++ b/api/v1beta1/grafanadatasource_types.go
@@ -40,13 +40,11 @@ type GrafanaDatasourceInternal struct {
 	Editable      *bool  `json:"editable,omitempty"`
 
 	// +kubebuilder:validation:Schemaless
-	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Type=object
 	// +optional
 	JSONData json.RawMessage `json:"jsonData,omitempty"`
 
 	// +kubebuilder:validation:Schemaless
-	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Type=object
 	// +optional
 	SecureJSONData json.RawMessage `json:"secureJsonData,omitempty"`

--- a/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
+++ b/config/crd/bases/grafana.integreatly.org_grafanadatasources.yaml
@@ -43,7 +43,6 @@ spec:
                     type: boolean
                   jsonData:
                     type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   name:
                     type: string
                   orgId:
@@ -51,7 +50,6 @@ spec:
                     type: integer
                   secureJsonData:
                     type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   type:
                     type: string
                   uid:

--- a/config/grafana.integreatly.org_grafanadatasources.yaml
+++ b/config/grafana.integreatly.org_grafanadatasources.yaml
@@ -51,7 +51,6 @@ spec:
                     type: boolean
                   jsonData:
                     type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   name:
                     type: string
                   orgId:
@@ -59,7 +58,6 @@ spec:
                     type: integer
                   secureJsonData:
                     type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   type:
                     type: string
                   uid:


### PR DESCRIPTION
I don't see why we should use `PreserveUnknownFields` it will only confuse people when they apply something but something potentially not happening.

It's better that the config is removed when they check the CR.