### PR TITLE
Fix Custom Folder Logic in Dashboard Controller

### DIFF
--- a/examples/dashboard_with_custom_folder/README.md
+++ b/examples/dashboard_with_custom_folder/README.md
@@ -1,0 +1,4 @@
+# Dashboard with folder in spec
+
+This example shows how to add assign a dashboard to a folder through the dashboard resource,
+avoiding the use of the GrafanaFolder resource.

--- a/examples/dashboard_with_custom_folder/resources.yaml
+++ b/examples/dashboard_with_custom_folder/resources.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  labels:
+    dashboards: "grafana"
+spec:
+  client:
+    preferIngress: true
+  config:
+    log:
+      mode: "console"
+    auth:
+      disable_login_form: "false"
+    security:
+      admin_user: root
+      admin_password: secret
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: grafanadashboard-with-custom-folder
+spec:
+  folder: "Custom Folder"
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  url: "https://raw.githubusercontent.com/integr8ly/grafana-operator/master/deploy/examples/remote/grafana-dashboard.json"


### PR DESCRIPTION
Fixes:
- Wrong field assignment in grafana API dashboard struct, resulting in folders not being assigned to the correct folder
- Change `deleteFolderIfEmpty` method to use UID instead of ID, according to https://grafana.com/docs/grafana/v8.4/http_api/folder/ The delete function uses a UID, rather than ID, as previously used.

Adds:
- Example dashboard_with_custom_folder deployment

Fixes #84 