### PR TITLE
fix: remove command override from manifests

### DIFF
--- a/bundle/manifests/grafana-operator-experimental.clusterserviceversion.yaml
+++ b/bundle/manifests/grafana-operator-experimental.clusterserviceversion.yaml
@@ -246,8 +246,6 @@ spec:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
-                command:
-                - /manager
                 image: controller:latest
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,9 +25,7 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - command:
-        - /manager
-        args:
+      - args:
         - --leader-elect
         image: controller:latest
         name: manager

--- a/helm/grafana-operator/templates/deployment.yaml
+++ b/helm/grafana-operator/templates/deployment.yaml
@@ -44,8 +44,6 @@ spec:
             {{- if .Values.leaderElect }}
             - --leader-elect
             {{- end }}
-          command:
-            - /manager
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
- Removed the command (=entrypoint) override from manifests:
  - When an image is built with ko, the binary is named differently, so `make deploy` will fail due to the command override in the manifests. I think we should not have it in manifests at all, the choice of binary name is up to a particular image whether it's build through existing Dockerfile or with `ko`.